### PR TITLE
Add simple pixel simulation and editor

### DIFF
--- a/Assets/Scripts/GameInitializer.cs
+++ b/Assets/Scripts/GameInitializer.cs
@@ -52,6 +52,15 @@ public class GameInitializer : MonoBehaviour
         groundObj.AddComponent<BoxCollider2D>();
         groundObj.GetComponent<BoxCollider2D>().sharedMaterial = new PhysicsMaterial2D { friction = 0.5f };
         groundObj.AddComponent<Rigidbody2D>().bodyType = RigidbodyType2D.Static;
+
+        // Pixel simulation
+        var simObj = new GameObject("PixelSimulation");
+        var simulation = simObj.AddComponent<PixelSimulation>();
+        simObj.transform.position = new Vector3(0, 0, 0);
+
+        var editorObj = new GameObject("PixelEditor");
+        var editor = editorObj.AddComponent<PixelEditor>();
+        editor.simulation = simulation;
     }
 
     Sprite CreateSquareSprite(Color color)

--- a/Assets/Scripts/Pixel.cs
+++ b/Assets/Scripts/Pixel.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class Pixel
+{
+    public PixelType Type;
+    public Color Color;
+
+    public Pixel(PixelType type, Color color)
+    {
+        Type = type;
+        Color = color;
+    }
+}

--- a/Assets/Scripts/PixelEditor.cs
+++ b/Assets/Scripts/PixelEditor.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+public class PixelEditor : MonoBehaviour
+{
+    public PixelSimulation simulation;
+    public Camera cam;
+
+    void Awake()
+    {
+        if (cam == null)
+            cam = Camera.main;
+    }
+
+    void Update()
+    {
+        if (simulation == null) return;
+        if (Input.GetMouseButton(0))
+            PlacePixel(PixelType.Solid, Color.gray);
+        if (Input.GetMouseButton(1))
+            PlacePixel(PixelType.Water, Color.blue);
+        if (Input.GetMouseButton(2))
+            PlacePixel(PixelType.Fire, Color.red);
+    }
+
+    void PlacePixel(PixelType type, Color color)
+    {
+        Vector3 world = cam.ScreenToWorldPoint(Input.mousePosition);
+        int x = Mathf.FloorToInt(simulation.width / 2 + world.x / simulation.pixelSize);
+        int y = Mathf.FloorToInt(simulation.height / 2 + world.y / simulation.pixelSize);
+        simulation.SetPixel(x, y, type, color);
+    }
+}

--- a/Assets/Scripts/PixelSimulation.cs
+++ b/Assets/Scripts/PixelSimulation.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+
+public class PixelSimulation : MonoBehaviour
+{
+    public int width = 64;
+    public int height = 64;
+    public float pixelSize = 0.1f;
+    public Pixel[,] pixels;
+    private Texture2D tex;
+    private SpriteRenderer sr;
+
+    void Awake()
+    {
+        sr = gameObject.AddComponent<SpriteRenderer>();
+        tex = new Texture2D(width, height) { filterMode = FilterMode.Point };
+        sr.sprite = Sprite.Create(tex, new Rect(0, 0, width, height), new Vector2(0.5f, 0.5f), 1 / pixelSize);
+        pixels = new Pixel[width, height];
+        for (int x = 0; x < width; x++)
+            for (int y = 0; y < height; y++)
+                pixels[x, y] = new Pixel(PixelType.Empty, Color.black);
+        Render();
+    }
+
+    void Update()
+    {
+        Simulate();
+        Render();
+    }
+
+    public void SetPixel(int x, int y, PixelType type, Color color)
+    {
+        if (x < 0 || x >= width || y < 0 || y >= height) return;
+        pixels[x, y].Type = type;
+        pixels[x, y].Color = color;
+    }
+
+    void SwapPixels(int x1, int y1, int x2, int y2)
+    {
+        var temp = pixels[x1, y1];
+        pixels[x1, y1] = pixels[x2, y2];
+        pixels[x2, y2] = temp;
+    }
+
+    void Simulate()
+    {
+        for (int y = 1; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                var p = pixels[x, y];
+                if (p.Type == PixelType.Water)
+                {
+                    if (pixels[x, y - 1].Type == PixelType.Empty)
+                        SwapPixels(x, y, x, y - 1);
+                }
+                else if (p.Type == PixelType.Acid)
+                {
+                    if (pixels[x, y - 1].Type == PixelType.Empty)
+                        SwapPixels(x, y, x, y - 1);
+                    else if (pixels[x, y - 1].Type == PixelType.Solid)
+                        SetPixel(x, y - 1, PixelType.Empty, Color.black);
+                }
+                else if (p.Type == PixelType.Fire)
+                {
+                    if (pixels[x, y - 1].Type == PixelType.Empty)
+                        SwapPixels(x, y, x, y - 1);
+                    if (Random.value < 0.01f)
+                        SetPixel(x, y, PixelType.Empty, Color.black);
+                }
+            }
+        }
+    }
+
+    void Render()
+    {
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                tex.SetPixel(x, y, pixels[x, y].Color);
+            }
+        }
+        tex.Apply();
+    }
+}

--- a/Assets/Scripts/PixelType.cs
+++ b/Assets/Scripts/PixelType.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+public enum PixelType
+{
+    Empty,
+    Solid,
+    Water,
+    Acid,
+    Fire
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This repository contains a small Unity 2D example that builds the entire scene using code.
 
 Scripts located in `Assets/Scripts` create the player, ground, and camera at runtime. Open the project in Unity and press Play to see the automatically generated scene.
+
+## Pixel Simulation
+
+The project now includes a very simple 2D pixel simulation inspired by **Noita**. Pixels can be placed using the mouse:
+
+* **Left click** – place solid pixels
+* **Right click** – place water pixels
+* **Middle click** – place fire pixels
+
+`PixelSimulation` manages a grid of pixels and applies basic gravity and interactions for water, acid, and fire. `PixelEditor` allows modifying the pixel grid at runtime.


### PR DESCRIPTION
## Summary
- create basic pixel types and a simple Pixel class
- implement `PixelSimulation` and `PixelEditor` with simple gravity and input controls
- initialize simulation objects in `GameInitializer`
- update README with instructions

## Testing
- `dotnet --version` *(fails: command not found)*
- `ls -1 Assets/Scripts | head`

------
https://chatgpt.com/codex/tasks/task_e_6865f27b2d008323a62b95af4ac35d90